### PR TITLE
fix: Use preformatted text for purl and cpe when writing markdown

### DIFF
--- a/sbom2doc/generator.py
+++ b/sbom2doc/generator.py
@@ -139,6 +139,9 @@ def generate_document(format, sbom_parser, filename, outfile, include_license):
                         cpe = reference[2]
             download = package.get("downloadlocation", "NOT KNOWN")
             copyright = package.get("copyrighttext", "-")
+            if isinstance(sbom_document, MarkdownBuilder):
+                purl = f"`{purl}`" if purl else ""
+                cpe = f"`{cpe}`" if cpe else ""
             sbom_document.addrow(
                 [
                     name,


### PR DESCRIPTION
I made a markdown doc and went to preview it, but the `cpe` field includes asterisks and some `purl`s may have underscores. Since markdown uses these to italicize text, I figured we could instead wrap those columns' content in \`\`.

Not sure if there's a better way to do this than `isinstance` so feel free to do it differently